### PR TITLE
repro and workaround the write barrier crash

### DIFF
--- a/corefoundation.go
+++ b/corefoundation.go
@@ -65,15 +65,17 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 }
 
 // CFDictionaryToMap converts CFDictionaryRef to a map.
-func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]C.CFTypeRef) {
+func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]uintptr) {
 	count := C.CFDictionaryGetCount(cfDict)
 	if count > 0 {
 		keys := make([]C.CFTypeRef, count)
 		values := make([]C.CFTypeRef, count)
 		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(&keys[0]), (*unsafe.Pointer)(&values[0]))
-		m = make(map[C.CFTypeRef]C.CFTypeRef, count)
+		m = make(map[C.CFTypeRef]uintptr, count)
 		for i := C.CFIndex(0); i < count; i++ {
-			m[keys[i]] = values[i]
+			k := keys[i]
+			v := values[i]
+			m[k] = uintptr(v)
 		}
 	}
 	return
@@ -254,7 +256,7 @@ func ConvertCFDictionary(d C.CFDictionaryRef) (map[interface{}]interface{}, erro
 		if err != nil {
 			return nil, err
 		}
-		gv, err := Convert(v)
+		gv, err := Convert(C.CFTypeRef(v))
 		if err != nil {
 			return nil, err
 		}

--- a/kext_test.go
+++ b/kext_test.go
@@ -2,22 +2,28 @@
 
 package kext
 
-import "testing"
+import (
+	"testing"
+	"fmt"
+)
 
 func TestInfoRaw(t *testing.T) {
-	info, err := LoadInfoRaw("com.github.osxfuse.filesystems.osxfusefs")
-	if err != nil {
-		t.Fatal(err)
+	for i := 0; i < 10000; i ++ {
+		fmt.Printf("%d....\n", i)
+		info, err := LoadInfoRaw("com.github.kbfuse.filesystems.kbfuse")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v", info)
 	}
-	t.Log("%v", info)
 }
 
 func TestInfo(t *testing.T) {
-	info, err := LoadInfo("com.github.osxfuse.filesystems.osxfusefs")
+	info, err := LoadInfo("com.github.kbfuse.filesystems.kbfuse")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log("%v", info)
+	t.Logf("%v", info)
 }
 
 func TestInfoNotFound(t *testing.T) {


### PR DESCRIPTION
- but i'm not sure why it was crashing.  it seem like it's OK to cast 0x27 to a `const void *`, it shouldn't get caught up on Go's garbage collector
- workaround it either way