### PR TITLE
Make compatible with go 1.10

### DIFF
--- a/corefoundation_1.10.go
+++ b/corefoundation_1.10.go
@@ -26,15 +26,15 @@ func Release(ref C.CFTypeRef) {
 // Release(ref).
 func BytesToCFData(b []byte) (C.CFDataRef, error) {
 	if uint64(len(b)) > math.MaxUint32 {
-		return nil, errors.New("Data is too large")
+		return 0, errors.New("Data is too large")
 	}
 	var p *C.UInt8
 	if len(b) > 0 {
 		p = (*C.UInt8)(&b[0])
 	}
 	cfData := C.CFDataCreate(nil, p, C.CFIndex(len(b)))
-	if cfData == nil {
-		return nil, fmt.Errorf("CFDataCreate failed")
+	if cfData == 0 {
+		return 0, fmt.Errorf("CFDataCreate failed")
 	}
 	return cfData, nil
 }
@@ -59,8 +59,8 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 		valuesPointer = &values[0]
 	}
 	cfDict := C.CFDictionaryCreate(nil, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
-	if cfDict == nil {
-		return nil, fmt.Errorf("CFDictionaryCreate failed")
+	if cfDict == 0 {
+		return 0, fmt.Errorf("CFDictionaryCreate failed")
 	}
 	return cfDict, nil
 }
@@ -71,7 +71,7 @@ func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]uintptr) {
 	if count > 0 {
 		keys := make([]C.CFTypeRef, count)
 		values := make([]C.CFTypeRef, count)
-		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(&keys[0]), (*unsafe.Pointer)(&values[0]))
+		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(unsafe.Pointer(&keys[0])), (*unsafe.Pointer)(unsafe.Pointer(&values[0])))
 		m = make(map[C.CFTypeRef]uintptr, count)
 		for i := C.CFIndex(0); i < count; i++ {
 			k := keys[i]
@@ -86,10 +86,10 @@ func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]uintptr) {
 // Release(ref).
 func StringToCFString(s string) (C.CFStringRef, error) {
 	if !utf8.ValidString(s) {
-		return nil, errors.New("Invalid UTF-8 string")
+		return 0, errors.New("Invalid UTF-8 string")
 	}
 	if uint64(len(s)) > math.MaxUint32 {
-		return nil, errors.New("String is too large")
+		return 0, errors.New("String is too large")
 	}
 
 	bytes := []byte(s)
@@ -140,7 +140,7 @@ func CFArrayToArray(cfArray C.CFArrayRef) (a []C.CFTypeRef) {
 	count := C.CFArrayGetCount(cfArray)
 	if count > 0 {
 		a = make([]C.CFTypeRef, count)
-		C.CFArrayGetValues(cfArray, C.CFRange{0, count}, (*unsafe.Pointer)(&a[0]))
+		C.CFArrayGetValues(cfArray, C.CFRange{0, count}, (*unsafe.Pointer)(unsafe.Pointer(&a[0])))
 	}
 	return
 }
@@ -158,7 +158,7 @@ func ConvertMapToCFDictionary(attr map[string]interface{}) (C.CFDictionaryRef, e
 		var valueRef C.CFTypeRef
 		switch i.(type) {
 		default:
-			return nil, fmt.Errorf("Unsupported value type: %v", reflect.TypeOf(i))
+			return 0, fmt.Errorf("Unsupported value type: %v", reflect.TypeOf(i))
 		case C.CFTypeRef:
 			valueRef = i.(C.CFTypeRef)
 		case bool:
@@ -170,35 +170,35 @@ func ConvertMapToCFDictionary(attr map[string]interface{}) (C.CFDictionaryRef, e
 		case []byte:
 			bytesRef, err := BytesToCFData(i.([]byte))
 			if err != nil {
-				return nil, err
+				return 0, err
 			}
 			valueRef = C.CFTypeRef(bytesRef)
 			defer Release(valueRef)
 		case string:
 			stringRef, err := StringToCFString(i.(string))
 			if err != nil {
-				return nil, err
+				return 0, err
 			}
 			valueRef = C.CFTypeRef(stringRef)
 			defer Release(valueRef)
 		case Convertable:
 			convertedRef, err := (i.(Convertable)).Convert()
 			if err != nil {
-				return nil, err
+				return 0, err
 			}
 			valueRef = C.CFTypeRef(convertedRef)
 			defer Release(valueRef)
 		}
 		keyRef, err := StringToCFString(key)
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
 		m[C.CFTypeRef(keyRef)] = valueRef
 	}
 
 	cfDict, err := MapToCFDictionary(m)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	return cfDict, nil
 }

--- a/corefoundation_1.10.go
+++ b/corefoundation_1.10.go
@@ -1,0 +1,340 @@
+// +build darwin ios
+// +build go1.10
+
+package kext
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation
+
+#include <CoreFoundation/CoreFoundation.h>
+*/
+import "C"
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"unicode/utf8"
+	"unsafe"
+)
+
+func Release(ref C.CFTypeRef) {
+	C.CFRelease(ref)
+}
+
+// BytesToCFData will return a CFDataRef and if non-nil, must be released with
+// Release(ref).
+func BytesToCFData(b []byte) (C.CFDataRef, error) {
+	if uint64(len(b)) > math.MaxUint32 {
+		return nil, errors.New("Data is too large")
+	}
+	var p *C.UInt8
+	if len(b) > 0 {
+		p = (*C.UInt8)(&b[0])
+	}
+	cfData := C.CFDataCreate(nil, p, C.CFIndex(len(b)))
+	if cfData == nil {
+		return nil, fmt.Errorf("CFDataCreate failed")
+	}
+	return cfData, nil
+}
+
+// CFDataToBytes converts CFData to bytes.
+func CFDataToBytes(cfData C.CFDataRef) ([]byte, error) {
+	return C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(cfData)), C.int(C.CFDataGetLength(cfData))), nil
+}
+
+// MapToCFDictionary will return a CFDictionaryRef and if non-nil, must be
+// released with Release(ref).
+func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error) {
+	var keys, values []unsafe.Pointer
+	for key, value := range m {
+		keys = append(keys, unsafe.Pointer(key))
+		values = append(values, unsafe.Pointer(value))
+	}
+	numValues := len(values)
+	var keysPointer, valuesPointer *unsafe.Pointer
+	if numValues > 0 {
+		keysPointer = &keys[0]
+		valuesPointer = &values[0]
+	}
+	cfDict := C.CFDictionaryCreate(nil, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
+	if cfDict == nil {
+		return nil, fmt.Errorf("CFDictionaryCreate failed")
+	}
+	return cfDict, nil
+}
+
+// CFDictionaryToMap converts CFDictionaryRef to a map.
+func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]uintptr) {
+	count := C.CFDictionaryGetCount(cfDict)
+	if count > 0 {
+		keys := make([]C.CFTypeRef, count)
+		values := make([]C.CFTypeRef, count)
+		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(&keys[0]), (*unsafe.Pointer)(&values[0]))
+		m = make(map[C.CFTypeRef]uintptr, count)
+		for i := C.CFIndex(0); i < count; i++ {
+			k := keys[i]
+			v := values[i]
+			m[k] = uintptr(v)
+		}
+	}
+	return
+}
+
+// StringToCFString will return a CFStringRef and if non-nil, must be released with
+// Release(ref).
+func StringToCFString(s string) (C.CFStringRef, error) {
+	if !utf8.ValidString(s) {
+		return nil, errors.New("Invalid UTF-8 string")
+	}
+	if uint64(len(s)) > math.MaxUint32 {
+		return nil, errors.New("String is too large")
+	}
+
+	bytes := []byte(s)
+	var p *C.UInt8
+	if len(bytes) > 0 {
+		p = (*C.UInt8)(&bytes[0])
+	}
+	return C.CFStringCreateWithBytes(nil, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
+}
+
+// CFStringToString converts a CFStringRef to a string.
+func CFStringToString(s C.CFStringRef) string {
+	p := C.CFStringGetCStringPtr(s, C.kCFStringEncodingUTF8)
+	if p != nil {
+		return C.GoString(p)
+	}
+	length := C.CFStringGetLength(s)
+	if length == 0 {
+		return ""
+	}
+	maxBufLen := C.CFStringGetMaximumSizeForEncoding(length, C.kCFStringEncodingUTF8)
+	if maxBufLen == 0 {
+		return ""
+	}
+	buf := make([]byte, maxBufLen)
+	var usedBufLen C.CFIndex
+	_ = C.CFStringGetBytes(s, C.CFRange{0, length}, C.kCFStringEncodingUTF8, C.UInt8(0), C.false, (*C.UInt8)(&buf[0]), maxBufLen, &usedBufLen)
+	return string(buf[:usedBufLen])
+}
+
+// ArrayToCFArray will return a CFArrayRef and if non-nil, must be released with
+// Release(ref).
+func ArrayToCFArray(a []C.CFTypeRef) C.CFArrayRef {
+	var values []unsafe.Pointer
+	for _, value := range a {
+		values = append(values, unsafe.Pointer(value))
+	}
+	numValues := len(values)
+	var valuesPointer *unsafe.Pointer
+	if numValues > 0 {
+		valuesPointer = &values[0]
+	}
+	return C.CFArrayCreate(nil, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
+}
+
+// CFArrayToArray converts a CFArrayRef to an array of CFTypes.
+func CFArrayToArray(cfArray C.CFArrayRef) (a []C.CFTypeRef) {
+	count := C.CFArrayGetCount(cfArray)
+	if count > 0 {
+		a = make([]C.CFTypeRef, count)
+		C.CFArrayGetValues(cfArray, C.CFRange{0, count}, (*unsafe.Pointer)(&a[0]))
+	}
+	return
+}
+
+// Convertable knows how to convert an instance to a CFTypeRef.
+type Convertable interface {
+	Convert() (C.CFTypeRef, error)
+}
+
+// ConvertMapToCFDictionary converts a map to a CFDictionary and if non-nil,
+// must be released with Release(ref).
+func ConvertMapToCFDictionary(attr map[string]interface{}) (C.CFDictionaryRef, error) {
+	m := make(map[C.CFTypeRef]C.CFTypeRef)
+	for key, i := range attr {
+		var valueRef C.CFTypeRef
+		switch i.(type) {
+		default:
+			return nil, fmt.Errorf("Unsupported value type: %v", reflect.TypeOf(i))
+		case C.CFTypeRef:
+			valueRef = i.(C.CFTypeRef)
+		case bool:
+			if i == true {
+				valueRef = C.CFTypeRef(C.kCFBooleanTrue)
+			} else {
+				valueRef = C.CFTypeRef(C.kCFBooleanFalse)
+			}
+		case []byte:
+			bytesRef, err := BytesToCFData(i.([]byte))
+			if err != nil {
+				return nil, err
+			}
+			valueRef = C.CFTypeRef(bytesRef)
+			defer Release(valueRef)
+		case string:
+			stringRef, err := StringToCFString(i.(string))
+			if err != nil {
+				return nil, err
+			}
+			valueRef = C.CFTypeRef(stringRef)
+			defer Release(valueRef)
+		case Convertable:
+			convertedRef, err := (i.(Convertable)).Convert()
+			if err != nil {
+				return nil, err
+			}
+			valueRef = C.CFTypeRef(convertedRef)
+			defer Release(valueRef)
+		}
+		keyRef, err := StringToCFString(key)
+		if err != nil {
+			return nil, err
+		}
+		m[C.CFTypeRef(keyRef)] = valueRef
+	}
+
+	cfDict, err := MapToCFDictionary(m)
+	if err != nil {
+		return nil, err
+	}
+	return cfDict, nil
+}
+
+// CFTypeDescription returns type string for CFTypeRef.
+func CFTypeDescription(ref C.CFTypeRef) string {
+	typeID := C.CFGetTypeID(ref)
+	typeDesc := C.CFCopyTypeIDDescription(typeID)
+	defer Release(C.CFTypeRef(typeDesc))
+	return CFStringToString(typeDesc)
+}
+
+// Convert converts a CFTypeRef to a go instance.
+func Convert(ref C.CFTypeRef) (interface{}, error) {
+	typeID := C.CFGetTypeID(ref)
+	if typeID == C.CFStringGetTypeID() {
+		return CFStringToString(C.CFStringRef(ref)), nil
+	} else if typeID == C.CFDictionaryGetTypeID() {
+		return ConvertCFDictionary(C.CFDictionaryRef(ref))
+	} else if typeID == C.CFArrayGetTypeID() {
+		arr := CFArrayToArray(C.CFArrayRef(ref))
+		results := make([]interface{}, 0, len(arr))
+		for _, ref := range arr {
+			v, err := Convert(ref)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, v)
+			return results, nil
+		}
+	} else if typeID == C.CFDataGetTypeID() {
+		b, err := CFDataToBytes(C.CFDataRef(ref))
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	} else if typeID == C.CFNumberGetTypeID() {
+		return CFNumberToInterface(C.CFNumberRef(ref)), nil
+	} else if typeID == C.CFBooleanGetTypeID() {
+		if C.CFBooleanGetValue(C.CFBooleanRef(ref)) != 0 {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	return nil, fmt.Errorf("Invalid type: %s", CFTypeDescription(ref))
+}
+
+// ConvertCFDictionary converts a CFDictionary to map (deep).
+func ConvertCFDictionary(d C.CFDictionaryRef) (map[interface{}]interface{}, error) {
+	m := CFDictionaryToMap(C.CFDictionaryRef(d))
+	result := make(map[interface{}]interface{})
+
+	for k, v := range m {
+		gk, err := Convert(k)
+		if err != nil {
+			return nil, err
+		}
+		gv, err := Convert(C.CFTypeRef(v))
+		if err != nil {
+			return nil, err
+		}
+		result[gk] = gv
+	}
+	return result, nil
+}
+
+// CFNumberToInterface converts the CFNumberRef to the most appropriate numeric
+// type.
+// This code is from github.com/kballard/go-osx-plist.
+func CFNumberToInterface(cfNumber C.CFNumberRef) interface{} {
+	typ := C.CFNumberGetType(cfNumber)
+	switch typ {
+	case C.kCFNumberSInt8Type:
+		var sint C.SInt8
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&sint))
+		return int8(sint)
+	case C.kCFNumberSInt16Type:
+		var sint C.SInt16
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&sint))
+		return int16(sint)
+	case C.kCFNumberSInt32Type:
+		var sint C.SInt32
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&sint))
+		return int32(sint)
+	case C.kCFNumberSInt64Type:
+		var sint C.SInt64
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&sint))
+		return int64(sint)
+	case C.kCFNumberFloat32Type:
+		var float C.Float32
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&float))
+		return float32(float)
+	case C.kCFNumberFloat64Type:
+		var float C.Float64
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&float))
+		return float64(float)
+	case C.kCFNumberCharType:
+		var char C.char
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&char))
+		return byte(char)
+	case C.kCFNumberShortType:
+		var short C.short
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&short))
+		return int16(short)
+	case C.kCFNumberIntType:
+		var i C.int
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&i))
+		return int32(i)
+	case C.kCFNumberLongType:
+		var long C.long
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&long))
+		return int(long)
+	case C.kCFNumberLongLongType:
+		// This is the only type that may actually overflow us
+		var longlong C.longlong
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&longlong))
+		return int64(longlong)
+	case C.kCFNumberFloatType:
+		var float C.float
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&float))
+		return float32(float)
+	case C.kCFNumberDoubleType:
+		var double C.double
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&double))
+		return float64(double)
+	case C.kCFNumberCFIndexType:
+		// CFIndex is a long
+		var index C.CFIndex
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&index))
+		return int(index)
+	case C.kCFNumberNSIntegerType:
+		// We don't have a definition of NSInteger, but we know it's either an int or a long
+		var nsInt C.long
+		C.CFNumberGetValue(cfNumber, typ, unsafe.Pointer(&nsInt))
+		return int(nsInt)
+	}
+	panic("Unknown CFNumber type")
+}

--- a/corefoundation_1.10.go
+++ b/corefoundation_1.10.go
@@ -66,17 +66,15 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 }
 
 // CFDictionaryToMap converts CFDictionaryRef to a map.
-func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]uintptr) {
+func CFDictionaryToMap(cfDict C.CFDictionaryRef) (m map[C.CFTypeRef]C.CFTypeRef) {
 	count := C.CFDictionaryGetCount(cfDict)
 	if count > 0 {
 		keys := make([]C.CFTypeRef, count)
 		values := make([]C.CFTypeRef, count)
 		C.CFDictionaryGetKeysAndValues(cfDict, (*unsafe.Pointer)(unsafe.Pointer(&keys[0])), (*unsafe.Pointer)(unsafe.Pointer(&values[0])))
-		m = make(map[C.CFTypeRef]uintptr, count)
+		m = make(map[C.CFTypeRef]C.CFTypeRef, count)
 		for i := C.CFIndex(0); i < count; i++ {
-			k := keys[i]
-			v := values[i]
-			m[k] = uintptr(v)
+			m[keys[i]] = values[i]
 		}
 	}
 	return
@@ -257,7 +255,7 @@ func ConvertCFDictionary(d C.CFDictionaryRef) (map[interface{}]interface{}, erro
 		if err != nil {
 			return nil, err
 		}
-		gv, err := Convert(C.CFTypeRef(v))
+		gv, err := Convert(v)
 		if err != nil {
 			return nil, err
 		}

--- a/corefoundation_pre1.10.go
+++ b/corefoundation_pre1.10.go
@@ -1,4 +1,7 @@
 // +build darwin ios
+// +build !go1.10
+
+// TODO: Remove this file once we've completely migrated to go 1.10.x.
 
 package kext
 

--- a/kext_1.10.go
+++ b/kext_1.10.go
@@ -33,18 +33,18 @@ func LoadInfo(kextID string) (*Info, error) {
 
 func LoadInfoRaw(kextID string) (map[interface{}]interface{}, error) {
 	cfKextID, err := StringToCFString(kextID)
-	if cfKextID != nil {
+	if cfKextID != 0 {
 		defer Release(C.CFTypeRef(cfKextID))
 	}
 	if err != nil {
 		return nil, err
 	}
 	cfKextIDs := ArrayToCFArray([]C.CFTypeRef{C.CFTypeRef(cfKextID)})
-	if cfKextIDs != nil {
+	if cfKextIDs != 0 {
 		defer Release(C.CFTypeRef(cfKextIDs))
 	}
 
-	cfDict := C.KextManagerCopyLoadedKextInfo(cfKextIDs, nil)
+	cfDict := C.KextManagerCopyLoadedKextInfo(C.CFArrayRef(cfKextIDs), 0)
 
 	m, err := ConvertCFDictionary(cfDict)
 	if err != nil {
@@ -66,7 +66,7 @@ func LoadInfoRaw(kextID string) (map[interface{}]interface{}, error) {
 
 func Load(kextID string, paths []string) error {
 	cfKextID, err := StringToCFString(kextID)
-	if cfKextID != nil {
+	if cfKextID != 0 {
 		defer Release(C.CFTypeRef(cfKextID))
 	}
 	if err != nil {
@@ -76,22 +76,22 @@ func Load(kextID string, paths []string) error {
 	var urls []C.CFTypeRef
 	for _, p := range paths {
 		cfPath, err := StringToCFString(p)
-		if cfPath != nil {
+		if cfPath != 0 {
 			defer Release(C.CFTypeRef(cfPath))
 		}
 		if err != nil {
 			return err
 		}
-		cfURL := C.CFURLCreateWithFileSystemPath(nil, cfPath, 0, 1)
+		cfURL := C.CFURLCreateWithFileSystemPath(nil, C.CFStringRef(cfPath), 0, 1)
 		if cfURL != 0 {
-			defer Release(C.CFTypeRef(cfURL))
+			defer Release(C.CFTypeRef(C.CFURLRef(cfURL)))
 		}
 
-		urls = append(urls, C.CFTypeRef(cfURL))
+		urls = append(urls, C.CFTypeRef(C.CFURLRef(cfURL)))
 	}
 
 	cfURLs := ArrayToCFArray(urls)
-	if cfURLs != nil {
+	if cfURLs != 0 {
 		defer Release(C.CFTypeRef(cfURLs))
 	}
 
@@ -104,7 +104,7 @@ func Load(kextID string, paths []string) error {
 
 func Unload(kextID string) error {
 	cfKextID, err := StringToCFString(kextID)
-	if cfKextID != nil {
+	if cfKextID != 0 {
 		defer Release(C.CFTypeRef(cfKextID))
 	}
 	if err != nil {

--- a/kext_1.10.go
+++ b/kext_1.10.go
@@ -83,7 +83,7 @@ func Load(kextID string, paths []string) error {
 			return err
 		}
 		cfURL := C.CFURLCreateWithFileSystemPath(nil, cfPath, 0, 1)
-		if cfURL != nil {
+		if cfURL != 0 {
 			defer Release(C.CFTypeRef(cfURL))
 		}
 

--- a/kext_1.10.go
+++ b/kext_1.10.go
@@ -1,0 +1,118 @@
+// +build darwin,!ios
+// +build go1.10
+
+package kext
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework IOKit
+
+#include <IOKit/kext/KextManager.h>
+*/
+import "C"
+import "fmt"
+
+type Info struct {
+	Version string
+	Started bool
+}
+
+func LoadInfo(kextID string) (*Info, error) {
+	info, err := LoadInfoRaw(kextID)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil {
+		return nil, nil
+	}
+
+	return &Info{
+		Version: info["CFBundleVersion"].(string),
+		Started: info["OSBundleStarted"].(bool),
+	}, nil
+}
+
+func LoadInfoRaw(kextID string) (map[interface{}]interface{}, error) {
+	cfKextID, err := StringToCFString(kextID)
+	if cfKextID != nil {
+		defer Release(C.CFTypeRef(cfKextID))
+	}
+	if err != nil {
+		return nil, err
+	}
+	cfKextIDs := ArrayToCFArray([]C.CFTypeRef{C.CFTypeRef(cfKextID)})
+	if cfKextIDs != nil {
+		defer Release(C.CFTypeRef(cfKextIDs))
+	}
+
+	cfDict := C.KextManagerCopyLoadedKextInfo(cfKextIDs, nil)
+
+	m, err := ConvertCFDictionary(cfDict)
+	if err != nil {
+		return nil, err
+	}
+
+	info, hasKey := m[kextID]
+	if !hasKey {
+		return nil, nil
+	}
+
+	var ret, cast = info.(map[interface{}]interface{})
+	if !cast {
+		return nil, fmt.Errorf("Unexpected value for kext info")
+	}
+
+	return ret, nil
+}
+
+func Load(kextID string, paths []string) error {
+	cfKextID, err := StringToCFString(kextID)
+	if cfKextID != nil {
+		defer Release(C.CFTypeRef(cfKextID))
+	}
+	if err != nil {
+		return err
+	}
+
+	var urls []C.CFTypeRef
+	for _, p := range paths {
+		cfPath, err := StringToCFString(p)
+		if cfPath != nil {
+			defer Release(C.CFTypeRef(cfPath))
+		}
+		if err != nil {
+			return err
+		}
+		cfURL := C.CFURLCreateWithFileSystemPath(nil, cfPath, 0, 1)
+		if cfURL != nil {
+			defer Release(C.CFTypeRef(cfURL))
+		}
+
+		urls = append(urls, C.CFTypeRef(cfURL))
+	}
+
+	cfURLs := ArrayToCFArray(urls)
+	if cfURLs != nil {
+		defer Release(C.CFTypeRef(cfURLs))
+	}
+
+	ret := C.KextManagerLoadKextWithIdentifier(cfKextID, cfURLs)
+	if ret != 0 {
+		return fmt.Errorf("Error loading kext(%d)", ret)
+	}
+	return nil
+}
+
+func Unload(kextID string) error {
+	cfKextID, err := StringToCFString(kextID)
+	if cfKextID != nil {
+		defer Release(C.CFTypeRef(cfKextID))
+	}
+	if err != nil {
+		return err
+	}
+	ret := C.KextManagerUnloadKextWithIdentifier(cfKextID)
+	if ret != 0 {
+		return fmt.Errorf("Error unloading kext (%d)", ret)
+	}
+	return nil
+}

--- a/kext_pre1.10.go
+++ b/kext_pre1.10.go
@@ -1,4 +1,7 @@
 // +build darwin,!ios
+// +build !go1.10
+
+// TODO: Remove this file once we've completely migrated to go 1.10.x.
 
 package kext
 


### PR DESCRIPTION
Split files by go version. This is a temporary measure until we fully
move to go 1.10.x.

Undo crash workaround in corefoundation_1.10.go. It is unnecessary
now that go 1.10 fixed the crash.