### PR TITLE
Fix C code to work with Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+
+os: osx
+
+before_install:
+  - go get golang.org/x/lint/golint
+
+script:
+  - go vet ./...
+  - golint ./...
+  - go test ./...
+
+go:
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - master

--- a/corefoundation_1.10.go
+++ b/corefoundation_1.10.go
@@ -45,7 +45,7 @@ func BytesToCFData(b []byte) (C.CFDataRef, error) {
 	if len(b) > 0 {
 		p = (*C.UInt8)(&b[0])
 	}
-	cfData := C.CFDataCreate(nil, p, C.CFIndex(len(b)))
+	cfData := C.CFDataCreate(C.kCFAllocatorDefault, p, C.CFIndex(len(b)))
 	if cfData == 0 {
 		return 0, fmt.Errorf("CFDataCreate failed")
 	}
@@ -71,7 +71,7 @@ func MapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) (C.CFDictionaryRef, error)
 		keysPointer = &keys[0]
 		valuesPointer = &values[0]
 	}
-	cfDict := C.CFDictionaryCreateSafe(nil, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
+	cfDict := C.CFDictionaryCreateSafe(C.kCFAllocatorDefault, keysPointer, valuesPointer, C.CFIndex(numValues), &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
 	if cfDict == 0 {
 		return 0, fmt.Errorf("CFDictionaryCreate failed")
 	}
@@ -108,7 +108,7 @@ func StringToCFString(s string) (C.CFStringRef, error) {
 	if len(bytes) > 0 {
 		p = (*C.UInt8)(&bytes[0])
 	}
-	return C.CFStringCreateWithBytes(nil, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
+	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, p, C.CFIndex(len(s)), C.kCFStringEncodingUTF8, C.false), nil
 }
 
 // CFStringToString converts a CFStringRef to a string.
@@ -143,7 +143,7 @@ func ArrayToCFArray(a []C.CFTypeRef) C.CFArrayRef {
 	if numValues > 0 {
 		valuesPointer = &values[0]
 	}
-	return C.CFArrayCreateSafe(nil, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
+	return C.CFArrayCreateSafe(C.kCFAllocatorDefault, valuesPointer, C.CFIndex(numValues), &C.kCFTypeArrayCallBacks)
 }
 
 // CFArrayToArray converts a CFArrayRef to an array of CFTypes.

--- a/kext_1.10.go
+++ b/kext_1.10.go
@@ -82,7 +82,7 @@ func Load(kextID string, paths []string) error {
 		if err != nil {
 			return err
 		}
-		cfURL := C.CFURLCreateWithFileSystemPath(nil, C.CFStringRef(cfPath), 0, 1)
+		cfURL := C.CFURLCreateWithFileSystemPath(C.kCFAllocatorDefault, C.CFStringRef(cfPath), 0, 1)
 		if cfURL != 0 {
 			defer Release(C.CFTypeRef(C.CFURLRef(cfURL)))
 		}


### PR DESCRIPTION
https://github.com/golang/go/commit/94076feef made C type checking stricter.
This caused problems where we were passing in nil for CFAllocatorRef, as Go 1.11
will require those to be 0 instead.

Use the typed constant kCFAllocatorDefault to avoid this problem.

Also add a .travis.yml config and test on various Go versions, including master.

This PR is a port of https://github.com/keybase/go-keychain/pull/31 .